### PR TITLE
Move stackoverflow2slack into this repo

### DIFF
--- a/.github/workflows/stackoverflow-slack-clean-cache.yaml
+++ b/.github/workflows/stackoverflow-slack-clean-cache.yaml
@@ -1,0 +1,30 @@
+name: "StackOverflow: Clean Actions Cache"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 0 * * *"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          echo "Fetching list of cache keys..."
+          cacheKeys=$(gh actions-cache list -R $REPO | cut -f 1)
+          cacheKeys=$(echo "$cacheKeys" | sed '1d')
+                
+          ## needed to not fail workflow while deleting keys
+          set +e
+
+          echo "Deleting old cache keys..."
+          for cacheKey in $cacheKeys; do
+            echo "Deleting $cacheKey..."
+            gh actions-cache delete $cacheKey -R $REPO --confirm
+          done
+          echo "Done!"

--- a/.github/workflows/stackoverflow-slack-get-questions.yaml
+++ b/.github/workflows/stackoverflow-slack-get-questions.yaml
@@ -1,0 +1,50 @@
+name: "StackOverflow: Fetch and Post StackOverflow Questions"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  fetch_and_post_questions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Restore statefile cache
+        uses: actions/cache/restore@v3
+        id: restore_cache
+        with:
+          path: state.txt
+          key: stackoverflow-state-
+          restore-keys: stackoverflow-state-
+
+      - name: Fetch and post questions
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "SLACK_WEBHOOK_URL secret is not set. Skipping the action."
+          else
+            python stackoverflow/action.py
+          fi
+
+      - name: Save statefile cache
+        uses: actions/cache/save@v3
+        if: always()
+        id: save_cache
+        with:
+          path: state.txt
+          key: stackoverflow-state-${{ github.run_id }}

--- a/stackoverflow/README.md
+++ b/stackoverflow/README.md
@@ -1,0 +1,57 @@
+# StackOverflow to Slack GitHub Action
+
+This GitHub Action fetches new StackOverflow questions tagged with
+`open-telemetry` and posts them to a Slack channel. It runs on an hourly
+schedule.
+
+## Setup
+
+1. Clone this repository or create a new repository with the provided
+   `action.py` script and `.github/workflows/get-questions.yml` workflow file.
+
+2. Create a Slack [incoming webhook
+   URL](https://api.slack.com/messaging/webhooks) for the Slack channel where
+   you want to post new questions.
+
+3. Add the webhook URL as a secret in your GitHub repository. Go to the
+   "Settings" tab of your GitHub repository, then click "Secrets" in the left
+   sidebar. Click "New repository secret" and add a secret with the name
+   `SLACK_WEBHOOK_URL` and the webhook URL value.
+
+4. Update the paths in the `.github/workflows/get-questions.yml` file to match
+   the locations of your `action.py` file.
+
+5. Push your changes to the repository. The GitHub Action will start running on an hourly schedule.
+
+## How it works
+
+The GitHub Action runs the `action.py` script, which fetches new StackOverflow
+questions tagged with `open-telemetry` and posts them to a Slack channel.
+
+In order to not repeat questions, the script stores the timestamp of the last
+seen question in a file called `state.txt`. This file is cached by the GitHub
+Actions runner and restored at the start of each run.
+
+Since GitHub Actions does not allow you to update a cache key, the action relies
+on the `restore-keys` behavior in `actions/cache`. This behavior checks for all
+keys that match a prefix, then restores the _most recent_ one. Each run of the
+action produces a new item (`state-<run id>`) in the cache, even if the
+timestamp doesn't change.
+
+In order to ensure that cache eviction occurs on our schedule,
+`clean-cache.yaml` exists. Daily, it deletes all keys except for the most recent
+one.
+
+## Contributing / Possible Improvements
+
+This should be pretty much done, but there's always improvements that could be
+made. A fun project might be to generate metrics about the questions being asked
+and publish them somewhere. Tags could be turned into links. There's a lot of
+stuff that you get back in the search results that we aren't using.
+[This page](https://api.stackexchange.com/docs/search#order=desc&sort=activity&tagged=open-telemetry&filter=default&site=stackoverflow&run=true)
+shows you the response object, we're only using a few of the fields. It might be
+nice to get the actual username, see how many answers exist already, etc.
+
+I believe we could also use the Slack API better; there's a lot you can do with
+it. See [this page](https://api.slack.com/reference/block-kit/blocks) for more
+on that topic.

--- a/stackoverflow/action.py
+++ b/stackoverflow/action.py
@@ -1,0 +1,105 @@
+import os
+import json
+import requests
+import logging
+from datetime import datetime
+
+STACK_OVERFLOW_API = "https://api.stackexchange.com/2.3/search"
+SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL')
+STATE_FILE = "state.txt"
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def get_latest_question_timestamp():
+    try:
+        with open(STATE_FILE, 'r') as f:
+            content = f.read().strip()
+            return int(content) if content else 0
+    except FileNotFoundError:
+        return 0
+
+def update_latest_question_timestamp(latest_timestamp):
+    with open(STATE_FILE, 'w') as f:
+        f.write(str(latest_timestamp))
+
+def fetch_questions(latest_timestamp):
+    params = {
+        "tagged": "open-telemetry;otel",
+        "sort": "creation",
+        "site": "stackoverflow"
+    }
+    if latest_timestamp > 0:
+        params["min"] = latest_timestamp + 1
+
+    response = requests.get(STACK_OVERFLOW_API, params=params)
+    response.raise_for_status()
+    return response.json().get('items', [])
+
+def format_question(question):
+    title = question['title']
+    link = question['link']
+    tags = [tag for tag in question['tags'] if tag != 'open-telemetry']
+    tags_str = ', '.join(tags)
+    message = {
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "New StackOverflow Question",
+                    "emoji": True
+                }
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"<{link}|{title}>\n*Tags:* {tags_str}"
+                }
+            },
+            {
+                "type": "divider"
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Posted at {datetime.fromtimestamp(question['creation_date']).strftime('%Y-%m-%d %H:%M:%S')}"
+                    }
+                ]
+            }
+        ],
+        "text": title
+    }
+    return message
+
+def post_to_slack(message):
+    if SLACK_WEBHOOK_URL:
+        headers = {"Content-Type": "application/json"}
+        data = {"text": message['text'], "blocks": message['blocks']}
+        response = requests.post(SLACK_WEBHOOK_URL, headers=headers, data=json.dumps(data))
+        response.raise_for_status()
+    else:
+        logging.info("SLACK_WEBHOOK_URL is not set. Logging the results instead.")
+        logging.info(f"Message: {message}")
+
+def main():
+    latest_timestamp = get_latest_question_timestamp()
+    logging.info(f"Latest question timestamp: {latest_timestamp}")
+    questions = fetch_questions(latest_timestamp)
+    logging.info(f"Fetched {len(questions)} questions from Stack Overflow")
+
+    for question in questions:
+        message = format_question(question)
+        logging.info(f"Formatting question: {question['title']}")
+        post_to_slack(message)
+        logging.info(f"Posted question to Slack: {question['title']}")
+        latest_timestamp = max(latest_timestamp, question['creation_date'])
+
+    update_latest_question_timestamp(latest_timestamp)
+    logging.info(f"Updated latest question timestamp: {latest_timestamp}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Moving over from https://github.com/open-telemetry/stackoverflow2slack so that we can archive that repository.

@austinlparker can you add the `SLACK_WEBHOOK_URL` secret to this repo?